### PR TITLE
Add ADC channel configuration on ADC-only pins

### DIFF
--- a/Firmware/src/HAL/Adc.cpp
+++ b/Firmware/src/HAL/Adc.cpp
@@ -189,12 +189,12 @@ Adc* Adc::from_string(const char *name)
         uint16_t modefunc = 1 << 4; // disable pullup,
         Chip_SCU_PinMuxSet(port, pin, modefunc);
 
+        // TODO do not hard code ADC0
+        Chip_SCU_ADC_Channel_Config(0, channel);
+    		
     } else {
         return nullptr;
     }
-
-    // TODO do not hard code ADC0
-    Chip_SCU_ADC_Channel_Config(0, channel);
 
     memset(sample_buffer, 0, sizeof(sample_buffer));
     memset(ave_buf, 0, sizeof(ave_buf));


### PR DESCRIPTION
This pull request defines the possibility to configure ADC channel on ADC-only pins. Currently ADC channel is configured on multiplexed pins whose analog function is selected through the ENAIO register in the SCU. However, when we want for instance to use ADC-only pins for thermistor and their correspondent multiplexed pins for something else, we will have issues through this ENAIO register. 

Now, my idea is to change this register when we only configure a multiplexed pin on config file and remain unchanged when we only configure an ADC-only pin.

Example:

Considering we want to connect thermistor pin on ADC0_0:
 
- If we want to configure thermistor on ADC-only pin:
hotend.thermistor_pin = ADC0_0     # Pin for the thermistor to read\n\

- If we want to configure thermistor on multiplexed pin with analog function:
hotend.thermistor_pin = p4_3     # Pin for the thermistor to read\n\